### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-playwright==1.43.0
+openai>=1.25.0          # official SDK
 python-dotenv>=1.0.1
 requests>=2.32.3
 typer[all]>=0.12.3


### PR DESCRIPTION
## Summary
- use official OpenAI Python SDK instead of Playwright

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_685dfb91dd708327bc2aad548e162b6a