### PR TITLE
Add system prompt support

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -36,7 +36,7 @@ class TradingBot:
         user_prompt = (
             f"Pair: {pair}\nDesired RR: {desired_rr}\nAmount (quote): {amount}\nLeverage: {leverage}"
         )
-        raw = self.chat.send_prompt(sys_prompt + "\n---\n" + user_prompt)
+        raw = self.chat.send_prompt(user_prompt, system_prompt=sys_prompt)
         try:
             proposal = json.loads(raw)
         except json.JSONDecodeError:

--- a/chatgpt/_interface.py
+++ b/chatgpt/_interface.py
@@ -22,8 +22,14 @@ class ChatGPTInterface:
     def close(self): pass
 
     # --- public --- #
-    def send_prompt(self, prompt: str) -> str:
-        messages: Sequence[Dict[str, str]] = [{"role": "user", "content": prompt}]
+    def send_prompt(self, prompt: str, system_prompt: str | None = None) -> str:
+        if system_prompt is not None:
+            messages: Sequence[Dict[str, str]] = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ]
+        else:
+            messages: Sequence[Dict[str, str]] = [{"role": "user", "content": prompt}]
         resp = openai.chat.completions.create(
             model=self.model,
             messages=messages,


### PR DESCRIPTION
## Summary
- allow sending a dedicated system prompt when talking to OpenAI
- pass separate user/system prompts when proposing a trade

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686100ab847c8327bc304ed96bdf643c