### PR TITLE
Centralize logging with configurable verbosity

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,5 +1,10 @@
 """CLI entry‑point using Typer + prompt‑toolkit."""
-import os, json, typer
+import logging
+import os
+import json
+
+import logging_config
+import typer
 from prompt_toolkit.completion import WordCompleter
 from dotenv import load_dotenv
 
@@ -23,8 +28,18 @@ def _check_env():
         raise typer.Exit(code=1)
 
 @app.command()
-def trade():
+def trade(
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Enable debug logging.",
+    )
+):
     """Interactive trade flow."""
+    if verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
     load_dotenv()
     _check_env()
 

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,24 @@
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+# Create logs directory next to this file
+log_dir = Path(__file__).resolve().parent / "logs"
+log_dir.mkdir(exist_ok=True)
+log_file = log_dir / "bot.log"
+
+formatter = logging.Formatter(
+    fmt="%(asctime)s | %(levelname)-8s | %(module)s:%(lineno)d \u2013 %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+
+file_handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
+file_handler.setFormatter(formatter)
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(formatter)
+
+root_logger = logging.getLogger()
+root_logger.setLevel(logging.INFO)
+root_logger.addHandler(file_handler)
+root_logger.addHandler(stream_handler)


### PR DESCRIPTION
## Summary
- introduce `logging_config.py` to configure log rotation and console output
- import `logging_config` at CLI startup
- add `--verbose / -v` option to enable debug logging

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68612445ce248327ab1c850e1094ee06